### PR TITLE
use mathjs for playground

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "eslint-config-next": "^13.4.1",
         "lucide-react": "^0.216.0",
         "mafs": "^0.16.0",
+        "mathjs": "^11.8.0",
         "next": "^13.4.1",
         "postcss": "8.4.23",
         "react": "18.2.0",
@@ -1139,6 +1140,18 @@
         "node": ">= 6"
       }
     },
+    "node_modules/complex.js": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/complex.js/-/complex.js-2.1.1.tgz",
+      "integrity": "sha512-8njCHOTtFFLtegk6zQo0kkVX1rngygb/KQI6z1qZxlFI3scluC+LVTCFbrkWjBv4vvLlbQ9t88IPMC6k95VTTg==",
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://www.patreon.com/infusion"
+      }
+    },
     "node_modules/computer-modern": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/computer-modern/-/computer-modern-0.1.2.tgz",
@@ -1198,6 +1211,11 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.3.tgz",
+      "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA=="
     },
     "node_modules/deep-equal": {
       "version": "2.2.1",
@@ -1454,6 +1472,11 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/escape-latex": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/escape-latex/-/escape-latex-1.2.0.tgz",
+      "integrity": "sha512-nV5aVWW1K0wEiUIEdZ4erkGGH8mDxGyxSeqPzRNtWP7ataw+/olFObw7hujFWlVjNsaDFw5VZ5NzVSIqRgfTiw=="
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -2724,6 +2747,11 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
     },
+    "node_modules/javascript-natural-sort": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/javascript-natural-sort/-/javascript-natural-sort-0.7.1.tgz",
+      "integrity": "sha512-nO6jcEfZWQXDhOiBtG2KvKyEptz7RVbpGP4vTD2hLBdmNQSsCiicO2Ioinv6UI4y9ukqnBpy+XZ9H6uLNgJTlw=="
+    },
     "node_modules/jiti": {
       "version": "1.18.2",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.18.2.tgz",
@@ -2923,6 +2951,28 @@
       "integrity": "sha512-4C7nX/dvpzB7za4Ql9K81xK3HPxCpHMgwTZVyf+9JQ6VUbn9jjZVN7/Nkdz/Ugzs2CSjqnL/UPXroiVBVHUWUw==",
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/mathjs": {
+      "version": "11.8.0",
+      "resolved": "https://registry.npmjs.org/mathjs/-/mathjs-11.8.0.tgz",
+      "integrity": "sha512-I7r8HCoqUGyEiHQdeOCF2m2k9N+tcOHO3cZQ3tyJkMMBQMFqMR7dMQEboBMJAiFW2Um3PEItGPwcOc4P6KRqwg==",
+      "dependencies": {
+        "@babel/runtime": "^7.21.0",
+        "complex.js": "^2.1.1",
+        "decimal.js": "^10.4.3",
+        "escape-latex": "^1.2.0",
+        "fraction.js": "^4.2.0",
+        "javascript-natural-sort": "^0.7.1",
+        "seedrandom": "^3.0.5",
+        "tiny-emitter": "^2.1.0",
+        "typed-function": "^4.1.0"
+      },
+      "bin": {
+        "mathjs": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/merge-stream": {
@@ -3943,6 +3993,11 @@
         "loose-envify": "^1.1.0"
       }
     },
+    "node_modules/seedrandom": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-3.0.5.tgz",
+      "integrity": "sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg=="
+    },
     "node_modules/semver": {
       "version": "7.5.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
@@ -4315,6 +4370,11 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tiny-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
+      "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q=="
+    },
     "node_modules/tiny-invariant": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.1.tgz",
@@ -4415,6 +4475,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-function": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/typed-function/-/typed-function-4.1.0.tgz",
+      "integrity": "sha512-DGwUl6cioBW5gw2L+6SMupGwH/kZOqivy17E4nsh1JI9fKF87orMmlQx3KISQPmg3sfnOUGlwVkroosvgddrlg==",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/typescript": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
       "name": "curvature",
       "version": "0.1.0",
       "dependencies": {
+        "@radix-ui/react-dialog": "^1.0.3",
+        "@radix-ui/react-label": "^2.0.1",
         "@radix-ui/react-slot": "^1.0.1",
         "@tabler/icons-react": "^2.19.0",
         "@types/node": "^20.1.2",
@@ -29,7 +31,9 @@
         "tailwind-merge": "^1.12.0",
         "tailwindcss": "3.3.2",
         "tailwindcss-animate": "^1.0.5",
-        "typescript": "5.0.4"
+        "typescript": "5.0.4",
+        "zod": "^3.21.4",
+        "zod-validation-error": "^1.3.0"
       },
       "devDependencies": {
         "@types/react-katex": "^3.0.0",
@@ -393,6 +397,14 @@
         "url": "https://opencollective.com/unts"
       }
     },
+    "node_modules/@radix-ui/primitive": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.0.0.tgz",
+      "integrity": "sha512-3e7rn8FDMin4CgeL7Z/49smCA3rFYY3Ha2rUQ7HRWFadS5iCRw08ZgVT1LaNTCNqgvrUiyczLflrVrF0SRQtNA==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      }
+    },
     "node_modules/@radix-ui/react-compose-refs": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.0.0.tgz",
@@ -404,6 +416,151 @@
         "react": "^16.8 || ^17.0 || ^18.0"
       }
     },
+    "node_modules/@radix-ui/react-context": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.0.0.tgz",
+      "integrity": "sha512-1pVM9RfOQ+n/N5PJK33kRSKsr1glNxomxONs5c49MliinBY6Yw2Q995qfBUUo0/Mbg05B/sGA0gkgPI7kmSHBg==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0"
+      }
+    },
+    "node_modules/@radix-ui/react-dialog": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.0.3.tgz",
+      "integrity": "sha512-owNhq36kNPqC2/a+zJRioPg6HHnTn5B/sh/NjTY8r4W9g1L5VJlrzZIVcBr7R9Mg8iLjVmh6MGgMlfoVf/WO/A==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/primitive": "1.0.0",
+        "@radix-ui/react-compose-refs": "1.0.0",
+        "@radix-ui/react-context": "1.0.0",
+        "@radix-ui/react-dismissable-layer": "1.0.3",
+        "@radix-ui/react-focus-guards": "1.0.0",
+        "@radix-ui/react-focus-scope": "1.0.2",
+        "@radix-ui/react-id": "1.0.0",
+        "@radix-ui/react-portal": "1.0.2",
+        "@radix-ui/react-presence": "1.0.0",
+        "@radix-ui/react-primitive": "1.0.2",
+        "@radix-ui/react-slot": "1.0.1",
+        "@radix-ui/react-use-controllable-state": "1.0.0",
+        "aria-hidden": "^1.1.1",
+        "react-remove-scroll": "2.5.5"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      }
+    },
+    "node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.0.3.tgz",
+      "integrity": "sha512-nXZOvFjOuHS1ovumntGV7NNoLaEp9JEvTht3MBjP44NSW5hUKj/8OnfN3+8WmB+CEhN44XaGhpHoSsUIEl5P7Q==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/primitive": "1.0.0",
+        "@radix-ui/react-compose-refs": "1.0.0",
+        "@radix-ui/react-primitive": "1.0.2",
+        "@radix-ui/react-use-callback-ref": "1.0.0",
+        "@radix-ui/react-use-escape-keydown": "1.0.2"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      }
+    },
+    "node_modules/@radix-ui/react-focus-guards": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.0.0.tgz",
+      "integrity": "sha512-UagjDk4ijOAnGu4WMUPj9ahi7/zJJqNZ9ZAiGPp7waUWJO0O1aWXi/udPphI0IUjvrhBsZJGSN66dR2dsueLWQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0"
+      }
+    },
+    "node_modules/@radix-ui/react-focus-scope": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.0.2.tgz",
+      "integrity": "sha512-spwXlNTfeIprt+kaEWE/qYuYT3ZAqJiAGjN/JgdvgVDTu8yc+HuX+WOWXrKliKnLnwck0F6JDkqIERncnih+4A==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-compose-refs": "1.0.0",
+        "@radix-ui/react-primitive": "1.0.2",
+        "@radix-ui/react-use-callback-ref": "1.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      }
+    },
+    "node_modules/@radix-ui/react-id": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.0.0.tgz",
+      "integrity": "sha512-Q6iAB/U7Tq3NTolBBQbHTgclPmGWE3OlktGGqrClPozSw4vkQ1DfQAOtzgRPecKsMdJINE05iaoDUG8tRzCBjw==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-use-layout-effect": "1.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0"
+      }
+    },
+    "node_modules/@radix-ui/react-label": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-label/-/react-label-2.0.1.tgz",
+      "integrity": "sha512-qcfbS3B8hTYmEO44RNcXB6pegkxRsJIbdxTMu0PEX0Luv5O2DvTIwwVYxQfUwLpM88EL84QRPLOLgwUSApMsLQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-primitive": "1.0.2"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      }
+    },
+    "node_modules/@radix-ui/react-portal": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.0.2.tgz",
+      "integrity": "sha512-swu32idoCW7KA2VEiUZGBSu9nB6qwGdV6k6HYhUoOo3M1FFpD+VgLzUqtt3mwL1ssz7r2x8MggpLSQach2Xy/Q==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-primitive": "1.0.2"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      }
+    },
+    "node_modules/@radix-ui/react-presence": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.0.0.tgz",
+      "integrity": "sha512-A+6XEvN01NfVWiKu38ybawfHsBjWum42MRPnEuqPsBZ4eV7e/7K321B5VgYMPv3Xx5An6o1/l9ZuDBgmcmWK3w==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-compose-refs": "1.0.0",
+        "@radix-ui/react-use-layout-effect": "1.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      }
+    },
+    "node_modules/@radix-ui/react-primitive": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-1.0.2.tgz",
+      "integrity": "sha512-zY6G5Qq4R8diFPNwtyoLRZBxzu1Z+SXMlfYpChN7Dv8gvmx9X3qhDqiLWvKseKVJMuedFeU/Sa0Sy/Ia+t06Dw==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-slot": "1.0.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      }
+    },
     "node_modules/@radix-ui/react-slot": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.0.1.tgz",
@@ -411,6 +568,52 @@
       "dependencies": {
         "@babel/runtime": "^7.13.10",
         "@radix-ui/react-compose-refs": "1.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0"
+      }
+    },
+    "node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.0.0.tgz",
+      "integrity": "sha512-GZtyzoHz95Rhs6S63D2t/eqvdFCm7I+yHMLVQheKM7nBD8mbZIt+ct1jz4536MDnaOGKIxynJ8eHTkVGVVkoTg==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0"
+      }
+    },
+    "node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.0.0.tgz",
+      "integrity": "sha512-FohDoZvk3mEXh9AWAVyRTYR4Sq7/gavuofglmiXB2g1aKyboUD4YtgWxKj8O5n+Uak52gXQ4wKz5IFST4vtJHg==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-use-callback-ref": "1.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0"
+      }
+    },
+    "node_modules/@radix-ui/react-use-escape-keydown": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.0.2.tgz",
+      "integrity": "sha512-DXGim3x74WgUv+iMNCF+cAo8xUHHeqvjx8zs7trKf+FkQKPQXLk2sX7Gx1ysH7Q76xCpZuxIJE7HLPxRE+Q+GA==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-use-callback-ref": "1.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0"
+      }
+    },
+    "node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.0.0.tgz",
+      "integrity": "sha512-6Tpkq+R6LOlmQb1R5NNETLG0B4YP0wc+klfXafpUCj6JGyaUc8il7/kUZ7m59rGbXGczE9Bs+iz2qloqsZBduQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
       },
       "peerDependencies": {
         "react": "^16.8 || ^17.0 || ^18.0"
@@ -724,6 +927,17 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+    },
+    "node_modules/aria-hidden": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.3.tgz",
+      "integrity": "sha512-xcLxITLe2HYa1cnYnwCjkOO1PqUHQpozB8x9AR0OgWN2woOBi5kSDVxKfd0b7sb1hw5qFeJhXm9H1nu3xSfLeQ==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/aria-query": {
       "version": "5.1.3",
@@ -1307,6 +1521,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/detect-node-es": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="
     },
     "node_modules/didyoumean": {
       "version": "1.2.2",
@@ -2118,6 +2337,14 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/get-nonce": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+      "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/get-stream": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
@@ -2388,6 +2615,14 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
       }
     },
     "node_modules/is-arguments": {
@@ -3767,6 +4002,73 @@
         "react": ">=15.3.2 <=18"
       }
     },
+    "node_modules/react-remove-scroll": {
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.5.5.tgz",
+      "integrity": "sha512-ImKhrzJJsyXJfBZ4bzu8Bwpka14c/fQt0k+cyFp/PBhTfyDnU5hjOtM4AG/0AMyy8oKzOTR0lDgJIM7pYXI0kw==",
+      "dependencies": {
+        "react-remove-scroll-bar": "^2.3.3",
+        "react-style-singleton": "^2.2.1",
+        "tslib": "^2.1.0",
+        "use-callback-ref": "^1.3.0",
+        "use-sidecar": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-remove-scroll-bar": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.4.tgz",
+      "integrity": "sha512-63C4YQBUt0m6ALadE9XV56hV8BgJWDmmTPY758iIJjfQKt2nYwoUrPk0LXRXcB/yIj82T1/Ixfdpdk68LwIB0A==",
+      "dependencies": {
+        "react-style-singleton": "^2.2.1",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-style-singleton": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.1.tgz",
+      "integrity": "sha512-ZWj0fHEMyWkHzKYUr2Bs/4zU6XLmq9HsgBURm7g5pAVfyn49DgUiNgY2d4lXRlYSiCif9YBGpQleewkcqddc7g==",
+      "dependencies": {
+        "get-nonce": "^1.0.0",
+        "invariant": "^2.2.4",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -4556,6 +4858,26 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/use-callback-ref": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.0.tgz",
+      "integrity": "sha512-3FT9PRuRdbB9HfXhEq35u4oZkvpJ5kuYbpqhCfmiZyReuRgpnhDlbr2ZEnnuS0RrJAPn6l23xjFg9kpDM+Ms7w==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/use-resize-observer": {
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/use-resize-observer/-/use-resize-observer-9.1.0.tgz",
@@ -4566,6 +4888,27 @@
       "peerDependencies": {
         "react": "16.8.0 - 18",
         "react-dom": "16.8.0 - 18"
+      }
+    },
+    "node_modules/use-sidecar": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.2.tgz",
+      "integrity": "sha512-epTbsLuzZ7lPClpz2TyryBfztm7m+28DlEv2ZCQ3MDr5ssiwyOwGH/e5F9CkfWjJ1t4clvI58yF822/GUkjjhw==",
+      "dependencies": {
+        "detect-node-es": "^1.1.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.9.0 || ^17.0.0 || ^18.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/util-deprecate": {
@@ -4678,6 +5021,17 @@
       "integrity": "sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-validation-error": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-1.3.0.tgz",
+      "integrity": "sha512-4WoQnuWnj06kwKR4A+cykRxFmy+CTvwMQO5ogTXLiVx1AuvYYmMjixh7sbkSsQTr1Fvtss6d5kVz8PGeMPUQjQ==",
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "zod": "^3.18.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@radix-ui/react-dialog": "^1.0.3",
+    "@radix-ui/react-label": "^2.0.1",
     "@radix-ui/react-slot": "^1.0.1",
     "@tabler/icons-react": "^2.19.0",
     "@types/node": "^20.1.2",
@@ -30,7 +32,9 @@
     "tailwind-merge": "^1.12.0",
     "tailwindcss": "3.3.2",
     "tailwindcss-animate": "^1.0.5",
-    "typescript": "5.0.4"
+    "typescript": "5.0.4",
+    "zod": "^3.21.4",
+    "zod-validation-error": "^1.3.0"
   },
   "devDependencies": {
     "@types/react-katex": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "eslint-config-next": "^13.4.1",
     "lucide-react": "^0.216.0",
     "mafs": "^0.16.0",
+    "mathjs": "^11.8.0",
     "next": "^13.4.1",
     "postcss": "8.4.23",
     "react": "18.2.0",

--- a/src/app/playground/page.tsx
+++ b/src/app/playground/page.tsx
@@ -1,11 +1,22 @@
 "use client";
 
+import { IconPlus, IconX } from "@tabler/icons-react";
 import * as math from "mathjs";
 import { ReactNode, useState } from "react";
 import { BlockMath, InlineMath } from "react-katex";
 import { Graph } from "~/components/graph";
 import { LessonLayout } from "~/components/lesson-layout";
+import { Button } from "~/components/ui/button";
 import { Input } from "~/components/ui/input";
+
+type Slider = {
+  variable: string;
+  value: number;
+  min?: number;
+  max?: number;
+  step?: number;
+  error?: string;
+};
 
 export default function Page() {
   // https://medium.com/swlh/how-to-store-a-function-with-the-usestate-hook-in-react-8a88dd4eede1
@@ -15,14 +26,24 @@ export default function Page() {
   const [xError, setXError] = useState("");
   const [yError, setYError] = useState("");
 
+  const [sliders, setSliders] = useState<Slider[]>([
+    { variable: "a", value: 1 },
+    { variable: "b", value: 3 },
+  ]);
+
+  // convert to {a: 1, b: 3} without using reduce
+  const scope = Object.fromEntries(
+    sliders.map((slider) => [slider.variable, slider.value])
+  );
+
   return (
     <LessonLayout
       title="Playground"
       graph={
         <Graph
           s={[
-            (t) => xNode.compile().evaluate({ t }),
-            (t) => yNode.compile().evaluate({ t }),
+            (t) => xNode.compile().evaluate({ ...scope, t }),
+            (t) => yNode.compile().evaluate({ ...scope, t }),
           ]}
         />
       }
@@ -48,7 +69,7 @@ export default function Page() {
                   throw new Error("Please enter an expression.");
                 const node = math.parse(e.target.value);
 
-                const test = node.compile().evaluate({ t: 1 });
+                const test = node.compile().evaluate({ ...scope, t: 1 });
                 if (typeof test !== "number")
                   throw new Error("Please enter a valid expression.");
 
@@ -83,7 +104,7 @@ export default function Page() {
                   throw new Error("Please enter an expression.");
                 const node = math.parse(e.target.value);
 
-                const test = node.compile().evaluate({ t: 1 });
+                const test = node.compile().evaluate({ ...scope, t: 1 });
                 if (typeof test !== "number")
                   throw new Error("Please enter a valid expression.");
 
@@ -101,6 +122,104 @@ export default function Page() {
             <span className="text-sm text-red-300">{yError}</span>
           )}
         </div>
+      </div>
+
+      <div className="flex items-center justify-between pt-4">
+        <p className="text-xl font-bold">Sliders</p>
+
+        <Button
+          variant="secondary"
+          size="sm"
+          className="h-6 px-2 py-0"
+          onClick={() => {
+            setSliders([
+              ...sliders,
+              {
+                variable: "c",
+                value: 0,
+              },
+            ]);
+          }}
+        >
+          <IconPlus
+            size={12}
+            className="mr-1  text-zinc-400 transition hover:text-zinc-500"
+          />
+
+          <span className="text-xs text-gray-400">Add Slider</span>
+        </Button>
+      </div>
+
+      <div className="flex flex-col gap-1 pt-2">
+        {sliders.map((slider) => (
+          <div key={slider.variable} className="flex flex-col">
+            <div className="flex items-center gap-2">
+              <input
+                type="range"
+                min={slider.min ?? -5}
+                max={slider.max ?? 5}
+                step={slider.step ?? 0.1}
+                value={slider.value}
+                onChange={(e) => {
+                  setSliders(
+                    sliders.map((s) =>
+                      s.variable === slider.variable
+                        ? { ...s, value: parseFloat(e.target.value) }
+                        : s
+                    )
+                  );
+                }}
+              />
+
+              <InlineMath math={`${slider.variable} = ${slider.value}`} />
+
+              <IconX
+                size={16}
+                className="cursor-pointer text-zinc-400 transition hover:text-zinc-500"
+                onClick={() => {
+                  // check if removing the slider will cause the equation to be invalid
+                  try {
+                    const xTest = xNode.compile().evaluate({
+                      ...scope,
+                      t: 1,
+                      [slider.variable]: undefined,
+                    });
+
+                    const yTest = yNode.compile().evaluate({
+                      ...scope,
+                      t: 1,
+                      [slider.variable]: undefined,
+                    });
+
+                    if (typeof xTest !== "number" || typeof yTest !== "number")
+                      throw new Error();
+                  } catch (e) {
+                    setSliders(
+                      sliders.map((s) =>
+                        s.variable === slider.variable
+                          ? {
+                              ...s,
+                              error:
+                                "Please remove references to this variable to delete it.",
+                            }
+                          : s
+                      )
+                    );
+
+                    return true;
+                  }
+
+                  setSliders(
+                    sliders.filter((s) => s.variable !== slider.variable)
+                  );
+                }}
+              />
+            </div>
+            {slider.error && (
+              <span className="text-sm text-red-300">{slider.error}</span>
+            )}
+          </div>
+        ))}
       </div>
     </LessonLayout>
   );

--- a/src/app/playground/page.tsx
+++ b/src/app/playground/page.tsx
@@ -2,7 +2,7 @@
 
 import { IconPlus, IconX } from "@tabler/icons-react";
 import * as math from "mathjs";
-import { ReactNode, useState } from "react";
+import { useState } from "react";
 import { BlockMath, InlineMath } from "react-katex";
 import { Graph } from "~/components/graph";
 import { LessonLayout } from "~/components/lesson-layout";
@@ -19,7 +19,6 @@ type Slider = {
 };
 
 export default function Page() {
-  // https://medium.com/swlh/how-to-store-a-function-with-the-usestate-hook-in-react-8a88dd4eede1
   const [xNode, setXNode] = useState<math.MathNode>(math.parse("t"));
   const [yNode, setYNode] = useState<math.MathNode>(math.parse("sin(t)"));
 
@@ -31,7 +30,6 @@ export default function Page() {
     { variable: "b", value: 3 },
   ]);
 
-  // convert to {a: 1, b: 3} without using reduce
   const scope = Object.fromEntries(
     sliders.map((slider) => [slider.variable, slider.value])
   );

--- a/src/app/playground/page.tsx
+++ b/src/app/playground/page.tsx
@@ -4,10 +4,28 @@ import { IconPlus, IconX } from "@tabler/icons-react";
 import * as math from "mathjs";
 import { useState } from "react";
 import { BlockMath, InlineMath } from "react-katex";
+import { ZodError, z } from "zod";
+import { fromZodError } from "zod-validation-error";
 import { Graph } from "~/components/graph";
 import { LessonLayout } from "~/components/lesson-layout";
 import { Button } from "~/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "~/components/ui/dialog";
 import { Input } from "~/components/ui/input";
+import { Label } from "~/components/ui/label";
+
+const sliderSchema = z.object({
+  variable: z.string().length(1, { message: "Must be a single character." }),
+  value: z.number(),
+  min: z.number().optional(),
+  max: z.number().optional(),
+  step: z.number().optional(),
+});
 
 type Slider = {
   variable: string;
@@ -24,6 +42,9 @@ export default function Page() {
 
   const [xError, setXError] = useState("");
   const [yError, setYError] = useState("");
+
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [dialogError, setDialogError] = useState("");
 
   const [sliders, setSliders] = useState<Slider[]>([
     { variable: "a", value: 1 },
@@ -124,28 +145,112 @@ export default function Page() {
 
       <div className="flex items-center justify-between pt-4">
         <p className="text-xl font-bold">Sliders</p>
+        <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+          <DialogTrigger asChild>
+            <Button
+              variant="secondary"
+              size="sm"
+              className="h-6 px-2 py-0"
+              onClick={() => {
+                setDialogError("");
+              }}
+            >
+              <IconPlus
+                size={12}
+                className="mr-1  text-zinc-400 transition hover:text-zinc-500"
+              />
 
-        <Button
-          variant="secondary"
-          size="sm"
-          className="h-6 px-2 py-0"
-          onClick={() => {
-            setSliders([
-              ...sliders,
-              {
-                variable: "c",
-                value: 0,
-              },
-            ]);
-          }}
-        >
-          <IconPlus
-            size={12}
-            className="mr-1  text-zinc-400 transition hover:text-zinc-500"
-          />
+              <span className="text-xs text-gray-400">Add Slider</span>
+            </Button>
+          </DialogTrigger>
 
-          <span className="text-xs text-gray-400">Add Slider</span>
-        </Button>
+          <DialogContent className="sm:max-w-[425px]">
+            <DialogHeader>
+              <DialogTitle>Add Slider</DialogTitle>
+            </DialogHeader>
+            <form
+              className="grid gap-4"
+              onSubmit={(e) => {
+                e.preventDefault();
+
+                const fd = new FormData(e.currentTarget);
+                const variable = fd.get("variable") as string;
+                const min = parseFloat((fd.get("min") as string) || "-5");
+                const max = parseFloat((fd.get("max") as string) || "5");
+                const step = parseFloat((fd.get("step") as string) || "0.1");
+                const value = (min + max) / 2;
+
+                if (variable === "t") {
+                  setDialogError("Cannot use variable 't'.");
+                  return;
+                } else if (sliders.some((s) => s.variable === variable)) {
+                  setDialogError("Variable already exists.");
+                  return;
+                }
+
+                try {
+                  const result = sliderSchema.parse({
+                    variable,
+                    value,
+                    min,
+                    max,
+                    step,
+                  });
+                  setSliders([...sliders, { ...result }]);
+                } catch (err) {
+                  const validationError = fromZodError(err as ZodError);
+                  setDialogError(validationError.message);
+                }
+              }}
+            >
+              <div className="grid grid-cols-4 items-center gap-4">
+                <Label htmlFor="variable" className="text-right">
+                  Variable
+                </Label>
+                <Input id="variable" name="variable" className="col-span-3" />
+              </div>
+              <div className="grid grid-cols-4 items-center gap-4">
+                <Label htmlFor="min" className="text-right">
+                  Min
+                </Label>
+                <Input
+                  id="min"
+                  name="min"
+                  className="col-span-3"
+                  placeholder="5"
+                />
+              </div>
+              <div className="grid grid-cols-4 items-center gap-4">
+                <Label htmlFor="max" className="text-right">
+                  Max
+                </Label>
+                <Input
+                  id="max"
+                  name="max"
+                  className="col-span-3"
+                  placeholder="-5"
+                />
+              </div>
+              <div className="grid grid-cols-4 items-center gap-4">
+                <Label htmlFor="step" className="text-right">
+                  Step
+                </Label>
+                <Input
+                  id="step"
+                  name="step"
+                  className="col-span-3"
+                  placeholder="0.1"
+                />
+              </div>
+
+              <p className="text-sm text-red-300">{dialogError}</p>
+
+              <Button type="submit" variant="secondary">
+                Submit
+              </Button>
+            </form>
+          </DialogContent>
+        </Dialog>
       </div>
 
       <div className="flex flex-col gap-1 pt-2">

--- a/src/app/playground/page.tsx
+++ b/src/app/playground/page.tsx
@@ -1,136 +1,107 @@
 "use client";
 
+import * as math from "mathjs";
 import { ReactNode, useState } from "react";
-import { InlineMath } from "react-katex";
+import { BlockMath, InlineMath } from "react-katex";
 import { Graph } from "~/components/graph";
 import { LessonLayout } from "~/components/lesson-layout";
 import { Input } from "~/components/ui/input";
-import { func } from "~/lib/utils";
 
 export default function Page() {
   // https://medium.com/swlh/how-to-store-a-function-with-the-usestate-hook-in-react-8a88dd4eede1
-  const [x, setX] = useState<func>(() => (t: number) => t);
-  const [y, setY] = useState<func>(() => (t: number) => Math.sin(t));
+  const [xNode, setXNode] = useState<math.MathNode>(math.parse("t"));
+  const [yNode, setYNode] = useState<math.MathNode>(math.parse("sin(t)"));
 
-  const [xHasError, setXHasError] = useState(false);
-  const [yHasError, setYHasError] = useState(false);
+  const [xError, setXError] = useState("");
+  const [yError, setYError] = useState("");
 
   return (
-    <LessonLayout title="Playground" graph={<Graph s={[x, y]} />}>
-      <p>
-        Please enter your functions in the form of JavaScript syntax. For
-        example, a sine wave would be represented as Math.sin(). This curve is
-        defined by the following parametric equations:
-      </p>
-
-      <div className="my-2 flex items-center gap-2">
-        <InlineMath math="x(t) =" />
-
-        <Input
-          type="text"
-          defaultValue="t"
-          onChange={(e) => {
-            const value = "(t) => " + e.target.value;
-            try {
-              // test if the function is valid
-              const test = eval(value)(1);
-              if (typeof test !== "number") throw new Error();
-              setX(() => eval(value));
-              setXHasError(false);
-            } catch {
-              // display error
-              setXHasError(true);
-            }
-          }}
-          className={"font-mono " + (xHasError ? "border border-red-500" : "")}
+    <LessonLayout
+      title="Playground"
+      graph={
+        <Graph
+          s={[
+            (t) => xNode.compile().evaluate({ t }),
+            (t) => yNode.compile().evaluate({ t }),
+          ]}
         />
+      }
+    >
+      <p>Please enter your own equations to draw out!</p>
+
+      <BlockMath
+        math={`x(t) = ${xNode.toTex()} \\\\ y(t) = ${yNode.toTex()}`}
+      />
+
+      <div className="my-2 flex items-start gap-2">
+        <span className="pt-2">
+          <InlineMath math="x(t) =" />
+        </span>
+
+        <div className="flex flex-col gap-1">
+          <Input
+            type="text"
+            defaultValue="t"
+            onChange={(e) => {
+              try {
+                if (e.target.value === "")
+                  throw new Error("Please enter an expression.");
+                const node = math.parse(e.target.value);
+
+                const test = node.compile().evaluate({ t: 1 });
+                if (typeof test !== "number")
+                  throw new Error("Please enter a valid expression.");
+
+                setXNode(node);
+                setXError("");
+              } catch (e) {
+                setXError((e as any).toString());
+              }
+            }}
+            className={
+              "font-mono " + (xError !== "" ? "border border-red-500" : "")
+            }
+          />
+          {xError !== "" && (
+            <span className="text-sm text-red-300">{xError}</span>
+          )}
+        </div>
       </div>
 
-      <div className="my-2 flex items-center gap-2">
-        <InlineMath math="y(t) =" />
+      <div className="my-2 flex items-start gap-2">
+        <span className="pt-2">
+          <InlineMath math="y(t) =" />
+        </span>
 
-        <Input
-          type="text"
-          defaultValue="Math.sin(t)"
-          onChange={(e) => {
-            const value = "(t) => " + e.target.value;
-            try {
-              // test if the function is valid
-              const test = eval(value)(1);
-              if (typeof test !== "number") throw new Error();
-              setY(() => eval(value));
-              setYHasError(false);
-            } catch {
-              // display error
-              setYHasError(true);
+        <div className="flex flex-col gap-1">
+          <Input
+            type="text"
+            defaultValue="sin(t)"
+            onChange={(e) => {
+              try {
+                if (e.target.value === "")
+                  throw new Error("Please enter an expression.");
+                const node = math.parse(e.target.value);
+
+                const test = node.compile().evaluate({ t: 1 });
+                if (typeof test !== "number")
+                  throw new Error("Please enter a valid expression.");
+
+                setYNode(node);
+                setYError("");
+              } catch (e) {
+                setYError((e as any).toString());
+              }
+            }}
+            className={
+              "font-mono " + (yError !== "" ? "border border-red-500" : "")
             }
-          }}
-          className={"font-mono " + (yHasError ? "border border-red-500" : "")}
-        />
+          />
+          {yError !== "" && (
+            <span className="text-sm text-red-300">{yError}</span>
+          )}
+        </div>
       </div>
-
-      <h3 className="mt-4 text-xl font-semibold">Syntax Cheat Sheet</h3>
-      <SyntaxCheatSheet />
     </LessonLayout>
-  );
-}
-
-function SyntaxCheatSheet() {
-  return (
-    <ul className="list-inside list-disc">
-      <li>
-        Addition: <Code>t + 5</Code>
-      </li>
-      <li>
-        Subtraction: <Code>t - 5</Code>
-      </li>
-      <li>
-        Multiplication: <Code>t * 5</Code>
-      </li>
-      <li>
-        Division: <Code>t / 5</Code>
-      </li>
-      <li>
-        Exponentiation: <Code>Math.pow(t, 2)</Code> or <Code>t**2</Code>
-      </li>
-      <li>
-        Square root: <Code>Math.sqrt(t)</Code>
-      </li>
-      <li>
-        Natural logarithm: <Code>Math.log(t)</Code>
-      </li>
-      <li>
-        Logarithm base 10: <Code>Math.log10(t)</Code>
-      </li>
-      <li>
-        Absolute value: <Code>Math.abs(t)</Code>
-      </li>
-      <li>
-        Sine: <Code>Math.sin(t)</Code>
-      </li>
-      <li>
-        Cosine: <Code>Math.cos(t)</Code>
-      </li>
-      <li>
-        Tangent: <Code>Math.tan(t)</Code>
-      </li>
-      <li>
-        Pi: <Code>Math.PI</Code>
-      </li>
-      <li>
-        Euler&apos;s number (e): <Code>Math.E</Code>
-      </li>
-      <li>
-        Rounding: <Code>Math.round(t)</Code>
-      </li>
-    </ul>
-  );
-}
-
-function Code({ children }: { children: ReactNode }) {
-  return (
-    <span className="rounded-md bg-zinc-800 px-1 py-0.5 font-mono text-sm">
-      {children}
-    </span>
   );
 }

--- a/src/app/playground/page.tsx
+++ b/src/app/playground/page.tsx
@@ -1,40 +1,14 @@
 "use client";
 
-import { IconPlus, IconX } from "@tabler/icons-react";
 import * as math from "mathjs";
 import { useState } from "react";
 import { BlockMath, InlineMath } from "react-katex";
-import { ZodError, z } from "zod";
-import { fromZodError } from "zod-validation-error";
 import { Graph } from "~/components/graph";
 import { LessonLayout } from "~/components/lesson-layout";
-import { Button } from "~/components/ui/button";
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from "~/components/ui/dialog";
 import { Input } from "~/components/ui/input";
-import { Label } from "~/components/ui/label";
-
-const sliderSchema = z.object({
-  variable: z.string().length(1, { message: "Must be a single character." }),
-  value: z.number(),
-  min: z.number().optional(),
-  max: z.number().optional(),
-  step: z.number().optional(),
-});
-
-type Slider = {
-  variable: string;
-  value: number;
-  min?: number;
-  max?: number;
-  step?: number;
-  error?: string;
-};
+import { Slider } from "./slider";
+import { SliderControl } from "./slider-control";
+import { SliderHeader } from "./slider-header";
 
 export default function Page() {
   const [xNode, setXNode] = useState<math.MathNode>(math.parse("t"));
@@ -42,9 +16,6 @@ export default function Page() {
 
   const [xError, setXError] = useState("");
   const [yError, setYError] = useState("");
-
-  const [dialogOpen, setDialogOpen] = useState(false);
-  const [dialogError, setDialogError] = useState("");
 
   const [sliders, setSliders] = useState<Slider[]>([
     { variable: "a", value: 1 },
@@ -143,185 +114,19 @@ export default function Page() {
         </div>
       </div>
 
-      <div className="flex items-center justify-between pt-4">
-        <p className="text-xl font-bold">Sliders</p>
-        <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
-          <DialogTrigger asChild>
-            <Button
-              variant="secondary"
-              size="sm"
-              className="h-6 px-2 py-0"
-              onClick={() => {
-                setDialogError("");
-              }}
-            >
-              <IconPlus
-                size={12}
-                className="mr-1  text-zinc-400 transition hover:text-zinc-500"
-              />
-
-              <span className="text-xs text-gray-400">Add Slider</span>
-            </Button>
-          </DialogTrigger>
-
-          <DialogContent className="sm:max-w-[425px]">
-            <DialogHeader>
-              <DialogTitle>Add Slider</DialogTitle>
-            </DialogHeader>
-            <form
-              className="grid gap-4"
-              onSubmit={(e) => {
-                e.preventDefault();
-
-                const fd = new FormData(e.currentTarget);
-                const variable = fd.get("variable") as string;
-                const min = parseFloat((fd.get("min") as string) || "-5");
-                const max = parseFloat((fd.get("max") as string) || "5");
-                const step = parseFloat((fd.get("step") as string) || "0.1");
-                const value = (min + max) / 2;
-
-                if (variable === "t") {
-                  setDialogError("Cannot use variable 't'.");
-                  return;
-                } else if (sliders.some((s) => s.variable === variable)) {
-                  setDialogError("Variable already exists.");
-                  return;
-                }
-
-                try {
-                  const result = sliderSchema.parse({
-                    variable,
-                    value,
-                    min,
-                    max,
-                    step,
-                  });
-                  setSliders([...sliders, { ...result }]);
-                } catch (err) {
-                  const validationError = fromZodError(err as ZodError);
-                  setDialogError(validationError.message);
-                }
-              }}
-            >
-              <div className="grid grid-cols-4 items-center gap-4">
-                <Label htmlFor="variable" className="text-right">
-                  Variable
-                </Label>
-                <Input id="variable" name="variable" className="col-span-3" />
-              </div>
-              <div className="grid grid-cols-4 items-center gap-4">
-                <Label htmlFor="min" className="text-right">
-                  Min
-                </Label>
-                <Input
-                  id="min"
-                  name="min"
-                  className="col-span-3"
-                  placeholder="5"
-                />
-              </div>
-              <div className="grid grid-cols-4 items-center gap-4">
-                <Label htmlFor="max" className="text-right">
-                  Max
-                </Label>
-                <Input
-                  id="max"
-                  name="max"
-                  className="col-span-3"
-                  placeholder="-5"
-                />
-              </div>
-              <div className="grid grid-cols-4 items-center gap-4">
-                <Label htmlFor="step" className="text-right">
-                  Step
-                </Label>
-                <Input
-                  id="step"
-                  name="step"
-                  className="col-span-3"
-                  placeholder="0.1"
-                />
-              </div>
-
-              <p className="text-sm text-red-300">{dialogError}</p>
-
-              <Button type="submit" variant="secondary">
-                Submit
-              </Button>
-            </form>
-          </DialogContent>
-        </Dialog>
-      </div>
+      <SliderHeader sliders={sliders} setSliders={setSliders} />
 
       <div className="flex flex-col gap-1 pt-2">
         {sliders.map((slider) => (
-          <div key={slider.variable} className="flex flex-col">
-            <div className="flex items-center gap-2">
-              <input
-                type="range"
-                min={slider.min ?? -5}
-                max={slider.max ?? 5}
-                step={slider.step ?? 0.1}
-                value={slider.value}
-                onChange={(e) => {
-                  setSliders(
-                    sliders.map((s) =>
-                      s.variable === slider.variable
-                        ? { ...s, value: parseFloat(e.target.value) }
-                        : s
-                    )
-                  );
-                }}
-              />
-
-              <InlineMath math={`${slider.variable} = ${slider.value}`} />
-
-              <IconX
-                size={16}
-                className="cursor-pointer text-zinc-400 transition hover:text-zinc-500"
-                onClick={() => {
-                  // check if removing the slider will cause the equation to be invalid
-                  try {
-                    const xTest = xNode.compile().evaluate({
-                      ...scope,
-                      t: 1,
-                      [slider.variable]: undefined,
-                    });
-
-                    const yTest = yNode.compile().evaluate({
-                      ...scope,
-                      t: 1,
-                      [slider.variable]: undefined,
-                    });
-
-                    if (typeof xTest !== "number" || typeof yTest !== "number")
-                      throw new Error();
-                  } catch (e) {
-                    setSliders(
-                      sliders.map((s) =>
-                        s.variable === slider.variable
-                          ? {
-                              ...s,
-                              error:
-                                "Please remove references to this variable to delete it.",
-                            }
-                          : s
-                      )
-                    );
-
-                    return true;
-                  }
-
-                  setSliders(
-                    sliders.filter((s) => s.variable !== slider.variable)
-                  );
-                }}
-              />
-            </div>
-            {slider.error && (
-              <span className="text-sm text-red-300">{slider.error}</span>
-            )}
-          </div>
+          <SliderControl
+            key={slider.variable}
+            slider={slider}
+            sliders={sliders}
+            setSliders={setSliders}
+            xNode={xNode}
+            yNode={yNode}
+            scope={scope}
+          />
         ))}
       </div>
     </LessonLayout>

--- a/src/app/playground/slider-control.tsx
+++ b/src/app/playground/slider-control.tsx
@@ -1,0 +1,90 @@
+import { IconX } from "@tabler/icons-react";
+import { Dispatch, SetStateAction } from "react";
+import { InlineMath } from "react-katex";
+import { Slider } from "./slider";
+
+type SliderControlProps = {
+  slider: Slider;
+  sliders: Slider[];
+  setSliders: Dispatch<SetStateAction<Slider[]>>;
+  xNode: math.MathNode;
+  yNode: math.MathNode;
+  scope: Record<string, number>;
+};
+
+export function SliderControl({
+  slider,
+  sliders,
+  setSliders,
+  xNode,
+  yNode,
+  scope,
+}: SliderControlProps) {
+  return (
+    <div key={slider.variable} className="flex flex-col">
+      <div className="flex items-center gap-2">
+        <input
+          type="range"
+          min={slider.min ?? -5}
+          max={slider.max ?? 5}
+          step={slider.step ?? 0.1}
+          value={slider.value}
+          onChange={(e) => {
+            setSliders(
+              sliders.map((s) =>
+                s.variable === slider.variable
+                  ? { ...s, value: parseFloat(e.target.value) }
+                  : s
+              )
+            );
+          }}
+        />
+
+        <InlineMath math={`${slider.variable} = ${slider.value}`} />
+
+        <IconX
+          size={16}
+          className="cursor-pointer text-zinc-400 transition hover:text-zinc-500"
+          onClick={() => {
+            // check if removing the slider will cause the equation to be invalid
+            try {
+              const xTest = xNode.compile().evaluate({
+                ...scope,
+                t: 1,
+                [slider.variable]: undefined,
+              });
+
+              const yTest = yNode.compile().evaluate({
+                ...scope,
+                t: 1,
+                [slider.variable]: undefined,
+              });
+
+              if (typeof xTest !== "number" || typeof yTest !== "number")
+                throw new Error();
+            } catch (e) {
+              setSliders(
+                sliders.map((s) =>
+                  s.variable === slider.variable
+                    ? {
+                        ...s,
+                        error:
+                          "Please remove references to this variable to delete it.",
+                      }
+                    : s
+                )
+              );
+
+              return true;
+            }
+
+            setSliders(sliders.filter((s) => s.variable !== slider.variable));
+          }}
+        />
+      </div>
+      {slider.error && (
+        <span className="text-sm text-red-300">{slider.error}</span>
+      )}
+    </div>
+  );
+}

--- a/src/app/playground/slider-header.tsx
+++ b/src/app/playground/slider-header.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+import { IconPlus } from "@tabler/icons-react";
+import { Dispatch, SetStateAction, useState } from "react";
+import { ZodError } from "zod";
+import { fromZodError } from "zod-validation-error";
+import { Button } from "~/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "~/components/ui/dialog";
+import { Input } from "~/components/ui/input";
+import { Label } from "~/components/ui/label";
+import { Slider, sliderSchema } from "./slider";
+
+type SliderHeaderProps = {
+  sliders: Slider[];
+  setSliders: Dispatch<SetStateAction<Slider[]>>;
+};
+
+export function SliderHeader({ sliders, setSliders }: SliderHeaderProps) {
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [dialogError, setDialogError] = useState("");
+
+  return (
+    <div className="flex items-center justify-between pt-4">
+      <p className="text-xl font-bold">Sliders</p>
+      <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+        <DialogTrigger asChild>
+          <Button
+            variant="secondary"
+            size="sm"
+            className="h-6 px-2 py-0"
+            onClick={() => {
+              setDialogError("");
+            }}
+          >
+            <IconPlus
+              size={12}
+              className="mr-1  text-zinc-400 transition hover:text-zinc-500"
+            />
+
+            <span className="text-xs text-gray-400">Add Slider</span>
+          </Button>
+        </DialogTrigger>
+
+        <DialogContent className="sm:max-w-[425px]">
+          <DialogHeader>
+            <DialogTitle>Add Slider</DialogTitle>
+          </DialogHeader>
+          <form
+            className="grid gap-4"
+            onSubmit={(e) => {
+              e.preventDefault();
+
+              const fd = new FormData(e.currentTarget);
+              const variable = fd.get("variable") as string;
+              const min = parseFloat((fd.get("min") as string) || "-5");
+              const max = parseFloat((fd.get("max") as string) || "5");
+              const step = parseFloat((fd.get("step") as string) || "0.1");
+              const value = (min + max) / 2;
+
+              if (variable === "t") {
+                setDialogError("Cannot use variable 't'.");
+                return;
+              } else if (sliders.some((s) => s.variable === variable)) {
+                setDialogError("Variable already exists.");
+                return;
+              }
+
+              try {
+                const result = sliderSchema.parse({
+                  variable,
+                  value,
+                  min,
+                  max,
+                  step,
+                });
+                setSliders([...sliders, { ...result }]);
+              } catch (err) {
+                const validationError = fromZodError(err as ZodError);
+                setDialogError(validationError.message);
+              }
+            }}
+          >
+            <div className="grid grid-cols-4 items-center gap-4">
+              <Label htmlFor="variable" className="text-right">
+                Variable
+              </Label>
+              <Input id="variable" name="variable" className="col-span-3" />
+            </div>
+            <div className="grid grid-cols-4 items-center gap-4">
+              <Label htmlFor="min" className="text-right">
+                Min
+              </Label>
+              <Input
+                id="min"
+                name="min"
+                className="col-span-3"
+                placeholder="5"
+              />
+            </div>
+            <div className="grid grid-cols-4 items-center gap-4">
+              <Label htmlFor="max" className="text-right">
+                Max
+              </Label>
+              <Input
+                id="max"
+                name="max"
+                className="col-span-3"
+                placeholder="-5"
+              />
+            </div>
+            <div className="grid grid-cols-4 items-center gap-4">
+              <Label htmlFor="step" className="text-right">
+                Step
+              </Label>
+              <Input
+                id="step"
+                name="step"
+                className="col-span-3"
+                placeholder="0.1"
+              />
+            </div>
+
+            <p className="text-sm text-red-300">{dialogError}</p>
+
+            <Button type="submit" variant="secondary">
+              Submit
+            </Button>
+          </form>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/src/app/playground/slider.ts
+++ b/src/app/playground/slider.ts
@@ -1,0 +1,18 @@
+import { z } from "zod";
+
+export const sliderSchema = z.object({
+  variable: z.string().length(1, { message: "Must be a single character." }),
+  value: z.number(),
+  min: z.number().optional(),
+  max: z.number().optional(),
+  step: z.number().optional(),
+});
+
+export type Slider = {
+  variable: string;
+  value: number;
+  min?: number;
+  max?: number;
+  step?: number;
+  error?: string;
+};

--- a/src/components/curvature.tsx
+++ b/src/components/curvature.tsx
@@ -45,6 +45,8 @@ export function Curvature({
   const R = 1 / k(t);
   const circle = vec.add(evalVec(s), vec.withMag(evalVec(dTds), R));
 
+  if (isNaN(circle[0]) || isNaN(circle[1])) return null;
+
   return (
     <>
       <Circle

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,0 +1,128 @@
+"use client"
+
+import * as React from "react"
+import * as DialogPrimitive from "@radix-ui/react-dialog"
+import { X } from "lucide-react"
+
+import { cn } from "~/lib/utils"
+
+const Dialog = DialogPrimitive.Root
+
+const DialogTrigger = DialogPrimitive.Trigger
+
+const DialogPortal = ({
+  className,
+  children,
+  ...props
+}: DialogPrimitive.DialogPortalProps) => (
+  <DialogPrimitive.Portal className={cn(className)} {...props}>
+    <div className="fixed inset-0 z-50 flex items-start justify-center sm:items-center">
+      {children}
+    </div>
+  </DialogPrimitive.Portal>
+)
+DialogPortal.displayName = DialogPrimitive.Portal.displayName
+
+const DialogOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn(
+      "fixed inset-0 z-50 bg-background/80 backdrop-blur-sm transition-all duration-100 data-[state=closed]:animate-out data-[state=closed]:fade-out data-[state=open]:fade-in",
+      className
+    )}
+    {...props}
+  />
+))
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName
+
+const DialogContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DialogPortal>
+    <DialogOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed z-50 grid w-full gap-4 rounded-b-lg border bg-background p-6 shadow-lg animate-in data-[state=open]:fade-in-90 data-[state=open]:slide-in-from-bottom-10 sm:max-w-lg sm:rounded-lg sm:zoom-in-90 data-[state=open]:sm:slide-in-from-bottom-0",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+        <X className="h-4 w-4" />
+        <span className="sr-only">Close</span>
+      </DialogPrimitive.Close>
+    </DialogPrimitive.Content>
+  </DialogPortal>
+))
+DialogContent.displayName = DialogPrimitive.Content.displayName
+
+const DialogHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col space-y-1.5 text-center sm:text-left",
+      className
+    )}
+    {...props}
+  />
+)
+DialogHeader.displayName = "DialogHeader"
+
+const DialogFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+      className
+    )}
+    {...props}
+  />
+)
+DialogFooter.displayName = "DialogFooter"
+
+const DialogTitle = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title
+    ref={ref}
+    className={cn(
+      "text-lg font-semibold leading-none tracking-tight",
+      className
+    )}
+    {...props}
+  />
+))
+DialogTitle.displayName = DialogPrimitive.Title.displayName
+
+const DialogDescription = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+DialogDescription.displayName = DialogPrimitive.Description.displayName
+
+export {
+  Dialog,
+  DialogTrigger,
+  DialogContent,
+  DialogHeader,
+  DialogFooter,
+  DialogTitle,
+  DialogDescription,
+}

--- a/src/components/ui/label.tsx
+++ b/src/components/ui/label.tsx
@@ -1,0 +1,26 @@
+"use client"
+
+import * as React from "react"
+import * as LabelPrimitive from "@radix-ui/react-label"
+import { VariantProps, cva } from "class-variance-authority"
+
+import { cn } from "~/lib/utils"
+
+const labelVariants = cva(
+  "text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+)
+
+const Label = React.forwardRef<
+  React.ElementRef<typeof LabelPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root> &
+    VariantProps<typeof labelVariants>
+>(({ className, ...props }, ref) => (
+  <LabelPrimitive.Root
+    ref={ref}
+    className={cn(labelVariants(), className)}
+    {...props}
+  />
+))
+Label.displayName = LabelPrimitive.Root.displayName
+
+export { Label }


### PR DESCRIPTION
The input boxes for the playground were previously using `eval()` to convert what the user typed in to a function that could be ran to define the curve. This worked alright, but the user had to use JavaScript syntax (such as `Math.sin()` or `**` instead of `^` for exponents) instead of normal math syntax. It also relied on `eval()`, meaning that the user could type in something like `alert("hi")` into the input and it would actually display the alert in the browser. This isn't a big deal since it's not like there's any arbitrary code running on the server (it's static), but it's still not a great look.

With this PR, I've switched to using [mathjs](https://mathjs.org/) to parse the input strings, which has the side benefit of allowing me to also [display the input as Tex](https://mathjs.org/docs/expressions/parsing.html#:~:text=and%20can%20be%20exported%20to%20LaTeX%20using). I've also finished up the playground page by adding sliders. The only thing left to do is to allow the user to input their own range for `t`, but I can do that at a later time.